### PR TITLE
Bump deps: Django & urllib3

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -13,4 +13,4 @@ cloudfoundry-client==1.16.0
 whitenoise
 gunicorn
 pdpyras
-urllib3==1.26.4
+urllib3==1.26.5

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 aiohttp==3.7.4
 dj-database-url
-django==3.1.6
+django==3.1.9
 django-environ
 django-jquery
 psycopg2-binary

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ django-jquery==3.1.0
     # via -r requirements.in
 django-staff-sso-client==3.1.0
     # via -r requirements.in
-django==3.1.6
+django==3.1.9
     # via
     #   -r requirements.in
     #   django-jquery

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,7 +86,7 @@ sqlparse==0.4.1
     # via django
 typing-extensions==3.7.4.3
     # via aiohttp
-urllib3==1.26.4
+urllib3==1.26.5
     # via
     #   -r requirements.in
     #   pdpyras


### PR DESCRIPTION
* Bump Django to 3.1.9 
This is a fix for CVE: GHSA-p99v-5w3c-jqq9

* Bump urllib3 to 1.26.5 …
This is a fix for CVE: GHSA-q2q7-5pp4-w6pg